### PR TITLE
Changed `Path` to `impl AsRef<Path>` in function signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use types::{LuaFunction, LuaObject};
 
 pub use libc::c_int;
 
-/// This macro is used to wrap a rust function in an `extern "C"` trampoline
+/// This macro is used to wrap a Rust function in an `extern "C"` trampoline
 /// to automatically pass a [`State`](state/struct.State.html) struct as the first
 /// argument instead of a `lua_State` raw pointer
 /// 
@@ -100,7 +100,7 @@ macro_rules! lua_func {
 
 /// This macro can be used to automatically generate a `luaL_Reg`
 /// struct for the provided method, with name `name`. It automatically
-/// reads an instances of struct `$st` from userdata and provides it as
+/// reads an instance of struct `$st` from userdata and provides it as
 /// an argument.
 #[macro_export]
 macro_rules! lua_method {

--- a/src/state.rs
+++ b/src/state.rs
@@ -39,7 +39,7 @@ pub struct State {
 }
 
 impl State {
-    /// Calls LUA C API to instantiate a new Lua state.
+    /// Calls Lua C API to instantiate a new Lua state.
     pub fn new() -> State {
         unsafe {
             State {
@@ -156,7 +156,7 @@ impl State {
         }
     }
 
-    /// Pops a value from the top of the stack
+    /// Pops `n` values from the top of the stack
     pub fn pop(&mut self, n: i32) {
         unsafe {
             lua_pop(self.state, n);
@@ -183,8 +183,7 @@ impl State {
         }
     }
 
-    /// Maps to `lua_call`, calls the function on the top of the
-    /// stack.
+    /// Maps to `lua_call`, calls the function on the top of the stack.
     pub fn call(&mut self, nargs: i32, nres: i32) {
         unsafe {
             lua_call(self.state, nargs, nres);
@@ -346,7 +345,7 @@ impl State {
         }
     }
 
-    /// Return the value on the stack at `idx` as an bool.
+    /// Return the value on the stack at `idx` as a bool.
     pub fn to_bool(&mut self, idx: c_int) -> Option<bool> {
         if self.is_bool(idx) {
             unsafe {
@@ -357,7 +356,7 @@ impl State {
         }
     }
 
-    /// Return the value on the stack at `idx` as an float.
+    /// Return the value on the stack at `idx` as a float.
     pub fn to_float(&mut self, idx: c_int) -> Option<f32> {
         if self.is_number(idx) {
             unsafe {
@@ -368,7 +367,7 @@ impl State {
         }
     }
 
-    /// Return the value on the stack at `idx` as an double.
+    /// Return the value on the stack at `idx` as a double.
     pub fn to_double(&mut self, idx: c_int) -> Option<f64> {
         if self.is_number(idx) {
             unsafe {
@@ -477,7 +476,7 @@ impl State {
         }
     }
 
-    /// Copys the value at `idx` to the top of the stack
+    /// Copies the value at `idx` to the top of the stack
     pub fn push_value(&mut self, idx: i32) {
         self.checkstack(1);
         unsafe {
@@ -567,7 +566,7 @@ impl State {
     }
 
     /// Gets a value `name` from the table on the stack at `idx` and
-    /// and pushes the fetched value to the top of the stack.
+    /// pushes the fetched value to the top of the stack.
     pub fn get_field(&mut self, idx: i32, name: &str) {
         self.checkstack(1);
         unsafe {
@@ -597,9 +596,9 @@ impl State {
         }
     }
 
-    /// Allocates a new Lua userdata block of size `sizeof(T)` for
-    /// use to store Rust objects on the Lua stack. The returned
-    /// pointer is owned by the Lua state.
+    /// Allocates a new Lua userdata block of size `sizeof(T)` to store
+    /// Rust objects on the Lua stack. The returned pointer is owned
+    /// by the Lua state.
     ///
     /// # Examples
     ///
@@ -697,9 +696,9 @@ impl State {
 
     /// Maps to `luaL_loadfile`, this method validates that the file exists
     /// before passing it into the Lua C API.
-    pub fn load_file(&mut self, path: &Path) -> Result<(), (ThreadStatus, String)> {
-        if path.is_file() {
-            let p = path.canonicalize().unwrap();
+    pub fn load_file(&mut self, path: impl AsRef<Path>) -> Result<(), (ThreadStatus, String)> {
+        if path.as_ref().is_file() {
+            let p = path.as_ref().canonicalize().unwrap();
             let full_path = p.to_string_lossy();
 
             unsafe {
@@ -718,7 +717,7 @@ impl State {
 
     /// Equivalent of `luaL_dofile`, loads a file and then immediately executes
     /// it with `pcall`, returning the result.
-    pub fn do_file(&mut self, path: &Path) -> Result<(), (ThreadStatus, String)> {
+    pub fn do_file(&mut self, path: impl AsRef<Path>) -> Result<(), (ThreadStatus, String)> {
         self.load_file(path).and_then(|_| {
             self.pcall(0, LUA_MULTIRET, 0)
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,8 +5,8 @@ use super::State;
 
 /// Represents any value that can be pushed onto the Lua stack
 pub trait LuaValue {
-    /// `push_val` should push the value of this type the the top
-    /// of the stack on Lua state `l`.
+    /// `push_val` should push the value of this type onto the top
+    /// of the stack of Lua state `l`.
     fn push_val(self, l: *mut ffi::lua_State);
 }
 
@@ -124,11 +124,11 @@ pub type LuaFunction = unsafe extern "C" fn(L: *mut ffi::lua_State) -> c_int;
 
 /// Structs can implement this trait to enable easy interaction with
 /// the Lua stack. Any struct implementing this trait can be pushed
-/// to the Lua stack as userdata.
+/// on the Lua stack as userdata.
 pub trait LuaObject {
     /// The string returned by this method will serve as the name
     /// of this type's metatable in the Lua registry. A good value
-    /// is the name of the type LuaObject is being implemented for.
+    /// is the name of the type for which LuaObject is being implemented.
     /// 
     /// The `c_str!` macro can be used to declare C string constants.
     fn name() -> *const i8;
@@ -137,8 +137,8 @@ pub trait LuaObject {
     /// be registered in the metatable automatically.
     fn lua_fns() -> Vec<ffi::luaL_Reg>;
 
-    // Return a list of all Lua metamethods on this struct. They will
-    // be registered in the metatable automatically.
+    /// Return a list of all Lua metamethods on this struct. They will
+    /// be registered in the metatable automatically.
     fn lua_meta_fns() -> Vec<ffi::luaL_Reg> {
         vec!()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use super::State;
 /// Represents any value that can be pushed onto the Lua stack
 pub trait LuaValue {
     /// `push_val` should push the value of this type onto the top
-    /// of the stack of Lua state `l`.
+    /// of the stack on Lua state `l`.
     fn push_val(self, l: *mut ffi::lua_State);
 }
 

--- a/tests/load_file.rs
+++ b/tests/load_file.rs
@@ -58,7 +58,7 @@ fn load_file() {
     let mut state = State::new();
     state.open_libs();
     state.register_struct::<Point2D>();
-    state.load_file(Path::new("./tests/lua/test1.lua")).unwrap();
+    state.load_file("./tests/lua/test1.lua").unwrap();
     
     let res = state.pcall(0, 0, 0);
     assert_eq!(res, Ok(()));
@@ -69,7 +69,7 @@ fn do_file() {
     let mut state = State::new();
     state.open_libs();
     state.register_struct::<Point2D>();
-    let res = state.do_file(Path::new("./tests/lua/test1.lua"));
+    let res = state.do_file("./tests/lua/test1.lua");
     
     assert_eq!(res, Ok(()));
 }
@@ -79,7 +79,7 @@ fn do_bad_file() {
     let mut state = State::new();
     state.open_libs();
     
-    let res = state.do_file(Path::new("./tests/lua/test2.lua"));
+    let res = state.do_file("./tests/lua/test2.lua");
 
     assert!(res.is_err());
 }


### PR DESCRIPTION
This way a consumer of the library can pass a regular string to, e.g., `State::do_file` without having to wrap it in `Path::new(...)` every time.